### PR TITLE
Dynamics callable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,10 @@ git:
 
 ## uncomment the following lines to override the default test script
 script:
- - julia -e 'Pkg.clone(pwd()); Pkg.build("RigidBodySim"); Pkg.test("RigidBodySim"; coverage=true)'
+ - julia -e 'Pkg.clone(pwd()); Pkg.checkout("RigidBodyDynamics"); Pkg.build("RigidBodySim"); Pkg.test("RigidBodySim"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("RigidBodySim")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
   - julia -e 'cd(Pkg.dir("RigidBodySim")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  # build documentation
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("RigidBodySim")); include(joinpath("docs", "make.jl"))'

--- a/docs/src/details.md
+++ b/docs/src/details.md
@@ -10,13 +10,18 @@ Order   = [:type, :function, :macro]
 ## ODE problem creation
 
 ```@docs
-ODEProblem
+Dynamics
+```
+
+```@docs
+ODEProblem(::RigidBodySim.Dynamics, ::Union{Base.AbstractVector, RigidBodyDynamics.MechanismState}, tspan)
 ```
 
 ## [Control](@id control)
 
 ```@docs
 zero_control!
+controlcallback
 PeriodicController
 ```
 

--- a/notebooks/Quick start guide.ipynb
+++ b/notebooks/Quick start guide.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook introduces the basic usage of the `RigidBodySim` package. Let's get started."
+    "This notebook introduces the basic usage of the RigidBodySim package. Let's get started."
    ]
   },
   {
@@ -19,14 +19,6 @@
    "execution_count": 1,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mRecompiling stale cache file /home/twan/code/RigidBodyDynamics/lib/v0.6/RigidBodySim.ji for module RigidBodySim.\n",
-      "\u001b[39m"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -142,7 +134,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mInteract.jl: using old nbwidgetsextension protocol\n",
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mInteract.jl: using new nbwidgetsextension protocol\n",
       "\u001b[39m"
      ]
     }
@@ -157,7 +149,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`RigidBodySim` reexports select symbols from RigidBodyTreeInspector.jl, as well as from packages in the [`DifferentialEquations`](https://github.com/JuliaDiffEq/DifferentialEquations.jl) ecosystem. To access additional `DifferentialEquations` features, simply add one or more of the following:\n",
+    "RigidBodySim reexports select symbols from RigidBodyTreeInspector.jl, as well as from packages in the [DifferentialEquations](https://github.com/JuliaDiffEq/DifferentialEquations.jl) ecosystem. To access additional DifferentialEquations features, simply add one or more of the following:\n",
     "```julia\n",
     "using DiffEqBase # basics\n",
     "using OrdinaryDiffEq # more ODE-related functionality\n",
@@ -206,10 +198,10 @@
    "source": [
     "state = MechanismState(mechanism)\n",
     "shoulder, elbow = joints(mechanism)\n",
-    "configuration(state, shoulder)[:] = 0.3\n",
-    "configuration(state, elbow)[:] = 0.4\n",
-    "velocity(state, shoulder)[:] = 1.\n",
-    "velocity(state, elbow)[:] = 2.;"
+    "configuration(state, shoulder) .= 0.3\n",
+    "configuration(state, elbow) .= 0.4\n",
+    "velocity(state, shoulder) .= 1.\n",
+    "velocity(state, elbow) .= 2.;"
    ]
   },
   {
@@ -223,16 +215,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`RigidBodySim` uses RigidBodyDynamics.jl to evaluate the equations of motion, and [OrdinaryDiffEq.jl](https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl) for numerical integration (see [DifferentialEquations.jl](https://github.com/JuliaDiffEq/DifferentialEquations.jl) for documentation).\n",
+    "RigidBodySim uses RigidBodyDynamics.jl to evaluate the equations of motion, and [OrdinaryDiffEq.jl](https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl) for numerical integration (see [DifferentialEquations.jl](https://github.com/JuliaDiffEq/DifferentialEquations.jl) for documentation).\n",
     "\n",
-    "`RigidBodySim` does not attempt to abstract away this dependence on the `DifferentialEquations` ecosystem, as doing so would necessarily expose only a subset of the functionality provided by `DifferentialEquations`, and require users familiar with the `DifferentialEquations` ecosystem to learn yet another API. Instead, `RigidBodySim` simply plugs into existing `DifferentialEquations` functionality, providing convenience methods and extensions.\n",
+    "RigidBodySim does not attempt to abstract away this dependence on the DifferentialEquations ecosystem, as doing so would necessarily expose only a subset of the functionality provided by DifferentialEquations, and require users familiar with the DifferentialEquations ecosystem to learn yet another API. Instead, RigidBodySim simply plugs into existing DifferentialEquations functionality, providing convenience methods and extensions.\n",
     "\n",
-    "One example of such a convience method is the following `DiffEqBase.ODEProblem` constructor, which sets up (but doesn't solve) the initial value problem to be solved through numerical integration of the equations of motion:"
+    "One example of this is the `Dynamics` object, which can represent the open-loop or closed-loop dynamics of a `Mechanism`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "open_loop_dynamics = Dynamics(mechanism);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Dynamics` object is callable, and satisfies the (in-place) [function signature that the OrdinaryDiffEq package expects](http://docs.juliadiffeq.org/stable/types/ode_types.html#Problem-Type-1), i.e. `f!(du, u, p, t)`. Furthermore the arguments with which the `Dynamics` object is called may have arbitrary element types.\n",
+    "\n",
+    "Using the `Dynamics` object we just created, we can now set up an `ODEProblem` as normal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -243,14 +253,21 @@
        "u0: [0.3, 0.4, 1.0, 2.0]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "final_time = 10000.\n",
-    "problem = ODEProblem(state, (0., final_time))"
+    "problem = ODEProblem(open_loop_dynamics, state, (0., final_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This sets up (but doesn't solve) the initial value problem to be solved through numerical integration of the equations of motion. Note that, as a convenience, RigidBodySim provides an `ODEProblem` constructor overload that (among other things) accepts a `MechanismState` object for the initial state (`u0`) argument."
    ]
   },
   {
@@ -264,25 +281,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`RigidBodySim` uses `RigidBodyTreeInspector` for visualization.\n",
+    "RigidBodySim uses RigidBodyTreeInspector.jl for visualization.\n",
     "\n",
-    "We'll begin by starting a new `DrakeVisualizer` process (a separate visualizer window) if one isn't running already:"
+    "We'll begin by starting a new DrakeVisualizer process (a separate visualizer window) if one isn't running already:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Bus::open: Can not get ibus-daemon's address. \n",
-      "IBusInputContext::createInputContext: no connection to ibus-daemon \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "any_open_visualizer_windows() || (new_visualizer_window(); sleep(1));"
    ]
@@ -291,7 +299,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For those familiar with `DrakeVisualizer`, note that `RigidBodySim.new_visualizer_window()` is different from `DrakeVisualizer.new_window()`: `RigidBodySim` provides a customized visualizer, with buttons that allow the user to interact with the simulation."
+    "For those familiar with DrakeVisualizer, note that `RigidBodySim.new_visualizer_window()` is different from `DrakeVisualizer.new_window()`: RigidBodySim provides a customized visualizer, with buttons that allow the user to interact with the simulation."
    ]
   },
   {
@@ -303,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,12 +332,12 @@
    "source": [
     "We don't just want to visualize the initial state; we want to visualize the mechanism during the simulation as well. In addition, we want to be able to interact with the simulation process (for example, by terminating it using the 'stop' button in the visualizer).\n",
     "\n",
-    "This functionality is implemented using a set of `DifferentialEquations` integrator callbacks (i.e., a `DiffEqBase.CallbackSet`). `RigidBodySim` provides a convenience `CallbackSet` constructor for these visualizer hooks:"
+    "This functionality is implemented using a set of DifferentialEquations integrator callbacks (i.e., a `DiffEqBase.CallbackSet`). RigidBodySim provides a convenience `CallbackSet` constructor for these visualizer hooks:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,22 +385,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  5.904990 seconds (597.29 k allocations: 29.213 MiB)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "problem = ODEProblem(state, (0., 5.))\n",
+    "problem = ODEProblem(open_loop_dynamics, state, (0., 5.))\n",
     "rate_limiter = RealtimeRateLimiter(max_rate = 1.)\n",
     "callbacks = CallbackSet(vis_callbacks, rate_limiter) # this is how you combine callbacks\n",
-    "@time solve(problem, Tsit5(), abs_tol = 1e-10, dt = 0.05, callback = callbacks);"
+    "solve(problem, Tsit5(), abs_tol = 1e-10, dt = 0.05, callback = callbacks);"
    ]
   },
   {
@@ -413,17 +413,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "problem = ODEProblem(state, (0., 5.))\n",
+    "problem = ODEProblem(open_loop_dynamics, state, (0., 5.))\n",
     "sol = solve(problem, Vern7(), abs_tol = 1e-10, dt = 0.05);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -482,7 +482,7 @@
        "control! (generic function with 1 method)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -496,11 +496,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "controlproblem = ODEProblem(state, (0., 5.), control!)\n",
+    "closed_loop_dynamics = Dynamics(mechanism, control!)\n",
+    "controlproblem = ODEProblem(closed_loop_dynamics, state, (0., 5.))\n",
     "sol = solve(controlproblem, Vern7(), abs_tol = 1e-10, dt = 0.05)\n",
     "animate(vis, state, sol)"
    ]
@@ -521,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -547,16 +548,16 @@
       "text/plain": [
        "DiffEqBase.ODEProblem with uType Array{Float64,1} and tType Float64. In-place: true\n",
        "timespan: (0.0, 5.0)\n",
-       "u0: [0.672518, -0.00976309, 1.22654, -0.585997]"
+       "u0: [-1.0405, 0.65953, 1.17022, -0.723217]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "periodic_control_problem = ODEProblem(state, (0., 5.), controller)"
+    "periodic_control_problem = ODEProblem(Dynamics(mechanism, controller), state, (0., 5.))"
    ]
   },
   {
@@ -568,7 +569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,17 +585,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Bus::open: Can not get ibus-daemon's address. \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animate(vis, state, sol)"
    ]

--- a/src/RigidBodySim.jl
+++ b/src/RigidBodySim.jl
@@ -33,6 +33,8 @@ export
 
 # Core
 export
+    Dynamics,
+    controlcallback,
     configuration_renormalizer,
     zero_control!,
     RealtimeRateLimiter

--- a/src/control.jl
+++ b/src/control.jl
@@ -48,11 +48,7 @@ and is used to stop ODE integration exactly every `Δt` seconds, so that the
 controller can be called. Typically, users will not have to explicitly create
 this `PeriodicCallback`, as it is automatically created and
 added to the `ODEProblem` when the `PeriodicController` is passed into the
-following `DiffEqBase.ODEProblem` constructor overload:
-
-```
-ODEProblem(state, tspan, controller::PeriodicController; callback)
-```
+RigidBodySim-provided `DiffEqBase.ODEProblem` constructor overload.
 
 # Examples
 
@@ -75,7 +71,7 @@ julia> pdcontrol!(τ, t, state) = (controlcalls[] += 1; τ .= -20 .* velocity(st
 julia> τ = zeros(velocity(state)); Δt = 1 / 200
 0.005
 
-julia> problem = ODEProblem(state, (0., 5.), PeriodicController(τ, Δt, pdcontrol!));
+julia> problem = ODEProblem(Dynamics(mechanism, PeriodicController(τ, Δt, pdcontrol!)), state, (0., 5.));
 
 julia> sol = solve(problem, Tsit5());
 

--- a/src/control.jl
+++ b/src/control.jl
@@ -16,7 +16,7 @@ using DocStringExtensions
     $(DOCSTRING)
     """
 
-import RigidBodySim.Core: create_ode_problem
+import RigidBodySim.Core: controlcallback
 import DiffEqBase
 import DiffEqBase: ODEProblem, CallbackSet, u_modified!
 import DiffEqCallbacks: PeriodicCallback
@@ -123,16 +123,14 @@ function PeriodicCallback(controller::PeriodicController)
     PeriodicCallback(f, controller.Δt; initialize = periodic_initialize, save_positions = controller.save_positions)
 end
 
+controlcallback(controller::PeriodicController) = PeriodicCallback(controller)
+
 function (controller::PeriodicController)(τ::AbstractVector, t, state)
     if controller.docontrol[]
         controller.control(controller.τ, t, state)
         controller.docontrol[] = false
     end
-    τ[:] = controller.τ
-end
-
-function ODEProblem(state::MechanismState, tspan, controller::PeriodicController; callback = nothing)
-    create_ode_problem(state, tspan, controller, CallbackSet(PeriodicCallback(controller), callback))
+    copy!(τ, controller.τ)
 end
 
 end # module

--- a/src/core.jl
+++ b/src/core.jl
@@ -48,11 +48,11 @@ struct Dynamics{M, JointCollection, C, P}
 end
 
 """
-Create a `Dynamics` object, representing the closed-loop dynamics of a `RigidBodyDynamics.Mechanism`.
+Create a `Dynamics` object, representing either the passive or closed-loop dynamics of a `RigidBodyDynamics.Mechanism`.
 
 The `control!` argument is a callable with the signature `control!(τ, t, state)`, where `τ` is the
 torque vector to be set in the body of `control!`, `t` is the current time, and `state` is a `MechanismState` object.
-By default, `control!` is [`zero_control!`](@ref).
+By default, `control!` is [`zero_control!`](@ref) (resulting in the passive dynamics).
 
 The `setparams!` keyword argument is a callable with the signature `setparams!(state, p)` where `state` is a
 `MechanismState` and `p` is a vector of parameters, as used in OrdinaryDiffEq.jl.
@@ -76,10 +76,10 @@ end
 """
 Can be used to create a callback associated with a given controller.
 """
-controlcallback(::Any) = nothing
+controlcallback(control!::Any) = nothing
 
 """
-Create a `DiffEqBase.ODEProblem` associated with the closed-loop dynamics of a `RigidBodyDynamics.Mechanism`.
+Create a `DiffEqBase.ODEProblem` associated with the dynamics of a `RigidBodyDynamics.Mechanism`.
 
 The initial state `x0` can be either a [`RigidBodyDynamics.MechanismState`]
 (http://JuliaRobotics.github.io/RigidBodyDynamics.jl/stable/mechanismstate.html#RigidBodyDynamics.MechanismState)),

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,6 +1,8 @@
 module Core
 
 export
+    Dynamics,
+    controlcallback,
     configuration_renormalizer,
     zero_control!,
     RealtimeRateLimiter
@@ -19,11 +21,13 @@ using DocStringExtensions
     """
 
 import DiffEqBase:
-    ODEProblem, DiscreteCallback, u_modified!
+    ODEProblem, DiscreteCallback, u_modified!, CallbackSet
 import DiffEqCallbacks:
     PeriodicCallback
 import RigidBodyDynamics:
+    Mechanism,
     MechanismState, DynamicsResult,
+    StateCache, DynamicsResultCache,
     velocity, configuration,
     num_positions, num_velocities, num_additional_states,
     set!, set_configuration!, normalize_configuration!,
@@ -35,81 +39,65 @@ A 'zero' controller, i.e. one that sets all control torques to zero at all times
 """
 zero_control!(τ::AbstractVector, t, state) = τ[:] = 0
 
-"""
-Create a `DiffEqBase.ODEProblem` representing the closed-loop dynamics of a
-`RigidBodyDynamics.Mechanism`.
+struct Dynamics{M, JointCollection, C, P}
+    statecache::StateCache{M, JointCollection}
+    resultcache::DynamicsResultCache{M}
+    # FIXME: τcache
+    control!::C
+    setparams!::P
+end
 
-The initial state is given by the `state` argument (a [`RigidBodyDynamics.MechanismState`](http://JuliaRobotics.github.io/RigidBodyDynamics.jl/release-0.4/mechanismstate.html#RigidBodyDynamics.MechanismState)).
-The `state` argument will be modified during the simulation, as it is used to evaluate the dynamics.
+"""
+Create a `Dynamics` object, representing the closed-loop dynamics of a `RigidBodyDynamics.Mechanism`.
 
 The `control!` argument is a callable with the signature `control!(τ, t, state)`, where `τ` is the
 torque vector to be set in the body of `control!`, `t` is the current time, and `state` is a `MechanismState` object.
 By default, `control!` is [`zero_control!`](@ref).
 
-The `callback` keyword argument can be used to pass in additional
-[DifferentialEquations.jl callbacks](http://docs.juliadiffeq.org/release-4.0/features/callback_functions.html#Using-Callbacks-1).
-
-# Examples
-
-The following is a ten second simulation of the passive dynamics of an Acrobot (double pendulum) with a
-`Vern7` integrator (see [DifferentialEquations.jl documentation](http://docs.juliadiffeq.org/release-4.0/solvers/ode_solve.html#Non-Stiff-Problems-1)).
-
-```jldoctest
-julia> using RigidBodySim, RigidBodyDynamics, OrdinaryDiffEq
-
-julia> mechanism = parse_urdf(Float64, Pkg.dir("RigidBodySim", "test", "urdf", "Acrobot.urdf"))
-Spanning tree:
-Vertex: world (root)
-  Vertex: base_link, Edge: base_link_to_world
-    Vertex: upper_link, Edge: shoulder
-      Vertex: lower_link, Edge: elbow
-No non-tree joints.
-
-julia> state = MechanismState(mechanism);
-
-julia> set_configuration!(state, [0.1; 0.2]);
-
-julia> problem = ODEProblem(state, (0., 10.))
-DiffEqBase.ODEProblem with uType Array{Float64,1} and tType Float64. In-place: true
-timespan: (0.0, 10.0)
-u0: [0.1, 0.2, 0.0, 0.0]
-
-julia> solution = solve(problem, Vern7());
-```
+The `setparams!` keyword argument is a callable with the signature `setparams!(state, p)` where `state` is a
+`MechanismState` and `p` is a vector of parameters, as used in OrdinaryDiffEq.jl.
 """
-function ODEProblem(state::MechanismState, tspan, control! = zero_control!; callback = nothing)
-    create_ode_problem(state, tspan, control!, callback)
+function Dynamics(mechanism::Mechanism, control! = zero_control!; setparams! = (state, p) -> nothing)
+    Dynamics(StateCache(mechanism), DynamicsResultCache(mechanism), control!, setparams!)
 end
 
-function create_ode_problem(state::MechanismState{X, M, C}, tspan, control!, callback) where {X, M, C}
-    # TODO: running controller at a reduced rate
-    # TODO: ability to affect external wrenches
-
-    result = DynamicsResult{C}(state.mechanism)
-    τ = similar(velocity(state))
-    q̇ = similar(configuration(state))
-    closed_loop_dynamics! = let state = state, result = result, τ = τ, q̇ = q̇ # https://github.com/JuliaLang/julia/issues/15276
-        function (ẋ, x, p, t)
-            # TODO: unpack function in RigidBodyDynamics:
-            nq = num_positions(state)
-            nv = num_velocities(state)
-            ns = num_additional_states(state)
-
-            set!(state, x)
-            configuration_derivative!(q̇, state)
-            control!(τ, t, state)
-            dynamics!(result, state, τ)
-
-            copy!(ẋ, 1, q̇, 1, nq)
-            copy!(ẋ, nq + 1, result.v̇, 1, nv)
-            copy!(ẋ, nq + nv + 1, result.ṡ, 1, ns)
-
-            ẋ
-        end
-    end
-    x = state_vector(state) # TODO: Vector constructor
-    ODEProblem(closed_loop_dynamics!, x, tspan; callback = callback)
+function (dynamics::Dynamics)(ẋ::AbstractVector, x::AbstractVector{X}, p, t) where X
+    state = dynamics.statecache[X]
+    result = dynamics.resultcache[X]
+    τ = similar(velocity(state)) # FIXME
+    copy!(state, x)
+    dynamics.setparams!(state, p)
+    dynamics.control!(τ, t, state)
+    dynamics!(result, state, τ)
+    copy!(ẋ, result)
+    nothing
 end
+
+"""
+Can be used to create a callback associated with a given controller.
+"""
+controlcallback(::Any) = nothing
+
+"""
+Create a `DiffEqBase.ODEProblem` associated with the closed-loop dynamics of a `RigidBodyDynamics.Mechanism`.
+
+The initial state `x0` can be either a [`RigidBodyDynamics.MechanismState`]
+(http://JuliaRobotics.github.io/RigidBodyDynamics.jl/stable/mechanismstate.html#RigidBodyDynamics.MechanismState)),
+or an `AbstractVector` containing the initial state represented as `[q; v; s]`, where `q` is the configuration vector,
+`v` is the velocity vector, and `s` is the vector of additional states.
+
+The `callback` keyword argument can be used to pass in additional [DifferentialEquations.jl callbacks]
+(http://docs.juliadiffeq.org/stable/features/callback_functions.html#Using-Callbacks-1).
+"""
+function ODEProblem(dynamics::Dynamics, x0::Union{AbstractVector, MechanismState}, tspan, p = nothing;
+        callback = nothing, kwargs...)
+    callbacks = CallbackSet(controlcallback(dynamics.control!), callback)
+    ODEProblem{true}(dynamics, Vector(x0), tspan, p; callback = callbacks, kwargs...)
+end
+
+Base.@deprecate(ODEProblem(state::MechanismState, tspan, control! = zero_control!; callback = nothing),
+    ODEProblem(Dynamics(state.mechanism, control!), state, tspan; callback = callback)
+)
 
 """
 `configuration_renormalizer` can be used to create a callback that projects the configuration
@@ -117,7 +105,8 @@ of a mechanism's state onto the configuration manifold. This may be necessary fo
 with e.g. quaternion-parameterized orientations as part of their joint configuration vectors,
 as numerical integration can cause the configuration to drift away from the unit norm constraints.
 
-The callback is implemented as a [`DiffEqCallbacks.DiscreteCallback`](http://docs.juliadiffeq.org/release-4.0/features/callback_functions.html#DiscreteCallback-1)
+The callback is implemented as a [`DiffEqCallbacks.DiscreteCallback`]
+(http://docs.juliadiffeq.org/stable/features/callback_functions.html#DiscreteCallback-1)
 By default, it is called at every integrator time step.
 """
 function configuration_renormalizer(state::MechanismState, condition = (u, t, integrator) -> true)

--- a/src/core.jl
+++ b/src/core.jl
@@ -30,7 +30,7 @@ import RigidBodyDynamics:
     StateCache, DynamicsResultCache,
     velocity, configuration,
     num_positions, num_velocities, num_additional_states,
-    set!, set_configuration!, normalize_configuration!,
+    set_configuration!, normalize_configuration!,
     configuration_derivative!, dynamics!, state_vector
 
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -173,7 +173,7 @@ julia> any_open_visualizer_windows() || (new_visualizer_window(); sleep(1));
 
 julia> vis = Visualizer(mechanism, parse_urdf(urdf, mechanism));
 
-julia> animate(vis, state, sol; realtime_rate = 0.5);
+julia> RigidBodySim.animate(vis, state, sol; realtime_rate = 0.5);
 ```
 """
 function animate(vis::Visualizer, state::MechanismState, sol::ODESolution;

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -102,7 +102,7 @@ function transform_publisher(state::MechanismState, vis::Visualizer, lcm::LCM; m
     action = let state = state, vis = vis, last_update_time = last_update_time, time_msg = time_msg, lcm = lcm
         function (integrator)
             last_update_time[] = time()
-            set!(state, integrator.u)
+            copy!(state, integrator.u)
             visualize(vis, integrator.t, state)
             u_modified!(integrator, false)
         end
@@ -194,7 +194,7 @@ function animate(vis::Visualizer, state::MechanismState, sol::ODESolution;
         end
         commands.terminate && (commands.terminate = false; break)
         x = sol(t)
-        set!(state, x)
+        copy!(state, x)
         normalize_configuration!(state)
         visualize(vis, t, state)
         framenum += 1

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -165,7 +165,7 @@ julia> state = MechanismState(mechanism);
 
 julia> set_configuration!(state, [0.1; 0.2]);
 
-julia> problem = ODEProblem(state, (0., 2.));
+julia> problem = ODEProblem(Dynamics(mechanism), state, (0., 2.));
 
 julia> sol = solve(problem, Vern7());
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,24 @@ function pause_message_sender(tpause::Number, pausecondition::Condition)
     DiscreteCallback(condition, action, save_positions=(false, false), initialize = initialize)
 end
 
+function dynamics_allocations(dynamics::Dynamics, state::MechanismState) # introduce function barrier
+    x = Vector(state)
+    ẋ = similar(x)
+    p = nothing
+    t = 3.
+    dynamics(ẋ, x, p, t)
+    allocs = @allocated dynamics(ẋ, x, p, t)
+end
+
+@testset "Dynamics" begin
+    srand(134)
+    mechanism = rand_tree_mechanism(Float64, [Revolute{Float64} for i = 1 : 30]...)
+    dynamics = Dynamics(mechanism)
+    state = MechanismState(mechanism)
+    rand!(state)
+    @test dynamics_allocations(dynamics, state) <= 80
+end
+
 @testset "compare to simulate" begin
     srand(1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,13 +45,13 @@ end
 
     state = MechanismState(mechanism)
     rand!(state)
-    x0 = state_vector(state) # TODO: Vector constructor
+    x0 = Vector(state)
 
     final_time = 5.
     problem = ODEProblem(state, (0., final_time))
     sol = solve(problem, Vern7(), abs_tol = 1e-10, dt = 0.05)
 
-    set!(state, x0)
+    copy!(state, x0)
     ts, qs, vs = RigidBodyDynamics.simulate(state, final_time)
 
     @test [qs[end]; vs[end]] ≈ sol[end] atol = 1e-2
@@ -131,7 +131,7 @@ end
     problem = ODEProblem(state, (0., 1e-3))
     sol = solve(problem, Vern7(), dt = 1e-4, callback = configuration_renormalizer(state))
 
-    set!(state, sol[end])
+    copy!(state, sol[end])
     @test RigidBodyDynamics.is_configuration_normalized(floatingjoint, configuration(state, floatingjoint))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ end
     x0 = Vector(state)
 
     final_time = 5.
-    problem = ODEProblem(state, (0., final_time))
+    problem = ODEProblem(Dynamics(mechanism), state, (0., final_time))
     sol = solve(problem, Vern7(), abs_tol = 1e-10, dt = 0.05)
 
     copy!(state, x0)
@@ -69,7 +69,7 @@ end
 
         tfinal = 100.
         dt = 1e-4
-        problem = ODEProblem(state, (0., tfinal))
+        problem = ODEProblem(Dynamics(mechanism), state, (0., tfinal))
 
         # Simulate for 3 seconds (wall time) and then send a termination command
         @async (sleep(3.); send_terminate_message())
@@ -88,7 +88,7 @@ end
         println("last(sol.t) after early termination 2: $(last(sol.t))")
 
         # Pause and unpause a short simulation, make sure that the simulation takes longer than without pausing
-        problem = ODEProblem(state, (0., 1.))
+        problem = ODEProblem(Dynamics(mechanism), state, (0., 1.))
         pausetime = 0.5
         pausecondition = Condition()
         pauser = pause_message_sender(pausetime, pausecondition)
@@ -108,7 +108,7 @@ end
         @test havepaused[]
 
         # Simulate for 3 seconds wall time, then pause, and then terminate a second later to make sure terminating works while paused
-        problem = ODEProblem(state, (0., tfinal))
+        problem = ODEProblem(Dynamics(mechanism), state, (0., tfinal))
         @async (sleep(3.); send_pause_message())
         @async (sleep(4.); send_terminate_message())
         sol = solve(problem, RK4(), adaptive = false, dt = dt, callback = vis_callbacks)
@@ -128,7 +128,7 @@ end
     rand!(configuration(state))
     @test !RigidBodyDynamics.is_configuration_normalized(floatingjoint, configuration(state, floatingjoint))
 
-    problem = ODEProblem(state, (0., 1e-3))
+    problem = ODEProblem(Dynamics(mechanism), state, (0., 1e-3))
     sol = solve(problem, Vern7(), dt = 1e-4, callback = configuration_renormalizer(state))
 
     copy!(state, sol[end])
@@ -160,7 +160,7 @@ end
         state = MechanismState(mechanism)
 
         final_time = 5.
-        problem = ODEProblem(state, (0., final_time))
+        problem = ODEProblem(Dynamics(mechanism), state, (0., final_time))
         sol = solve(problem, Vern7(), abs_tol = 1e-10, dt = 0.05)
 
         # regular playback
@@ -209,7 +209,7 @@ end
         τ[2] = cos(t)
     end; initialize = initialize)
     final_time = 25.3
-    problem = ODEProblem(state, (0., final_time), controller)
+    problem = ODEProblem(Dynamics(mechanism, controller), state, (0., final_time))
 
     # ensure that controller gets called at appropriate times:
     sol = solve(problem, Vern7(), abs_tol = 1e-10, dt = 0.05)


### PR DESCRIPTION
Add `Dynamics` callable, which enables `ODEProblem` construction with both open-loop and closed-loop dynamics that more closely matches the normal way you construct `ODEProblem`s. `Dynamics` internally uses `StateCache` and `DynamicsResultCache`, making it type-generic and thus allowing e.g. future use with stiff integrators that compute gradients using automatic differentiation. It also holds a `setparams!` callable, which in the future can be used to integrate with the DifferentialEquations parameter estimation functionality.

Also adapt to RigidBodyDynamics deprecations on master.

Still to do before merging:
 - [x] make a cache for the control torque vector instead of allocating a new one every step
 - [x] update Documenter docs.
