### PR TITLE
Add test with stiff integrator

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -24,6 +24,7 @@ import DiffEqBase:
     ODEProblem, DiscreteCallback, u_modified!, CallbackSet
 import DiffEqCallbacks:
     PeriodicCallback
+import DiffEqDiffTools
 import RigidBodyDynamics:
     Mechanism,
     MechanismState, DynamicsResult,
@@ -34,7 +35,7 @@ import RigidBodyDynamics:
     set_configuration!, normalize_configuration!,
     configuration_derivative!, dynamics!,
     ranges
-
+import ForwardDiff
 
 """
 A 'zero' controller, i.e. one that sets all control torques to zero at all times.
@@ -81,6 +82,10 @@ function (dynamics::Dynamics)(ẋ::AbstractVector, x::AbstractVector{X}, p, t::T
     copy!(ẋ, result)
     ẋ
 end
+
+# Disable ForwardDiff tag mechanism to work around https://github.com/JuliaDiff/ForwardDiff.jl/issues/267
+# The Tag type becomes too complicated due to the TypeSortedCollection type parameter, resulting in inference issues
+ForwardDiff.Tag(::DiffEqDiffTools.UJacobianWrapper{<:Dynamics}, ::Type{V}) where {V} = nothing
 
 """
 Can be used to create a callback associated with a given controller.

--- a/src/lcmtypes.jl
+++ b/src/lcmtypes.jl
@@ -5,7 +5,6 @@ export
     UTimeT
 
 using LCMCore
-using StaticArrays
 
 mutable struct CommsT <: LCMType
     utime::Int64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,7 @@ end
         @async (sleep(pause_time); send_pause_message())
         @async (sleep(termination_time); send_terminate_message())
         elapsed = @elapsed animate(vis, state, sol, realtime_rate = realtime_rate)
+        @show elapsed
         @test elapsed ≈ termination_time atol = 0.2 # higher atol because of pause poll int
     finally
         kill(visualizer_process)


### PR DESCRIPTION
This tests the ability of the new `Dynamics` callable to handle other scalar types, in particular `ForwardDiff.Dual`.

Note the workaround for https://github.com/JuliaDiff/ForwardDiff.jl/issues/267.