### PR TITLE
fix number of frames in animation

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -257,7 +257,7 @@ function MeshCatMechanisms.setanimation!(vis::MechanismVisualizer, sol::ODESolut
     @assert max_fps > 0
     @assert 0 < realtime_rate < Inf
     t0, tf = first(sol.t), last(sol.t)
-    ts = linspace(t0, tf, (tf - t0) * max_fps)
+    ts = linspace(t0, tf, round(Int, (tf - t0) * max_fps + 1))
     qs = let state = vis.state, sol = sol
         map(ts) do t
             x = sol(t)


### PR DESCRIPTION
If t0 = 0 and t1 = 1 and fps = 1, then we want the animation to show 2 frames, one at t=0 and one at t=1. So the actual frame count should be `(t1 - t0) * fps + 1`. This also fixes the InexactError when `(t1 - t0) * fps` is not an integer. 